### PR TITLE
Nn 565 - adding links to view offenders in New Nomis

### DIFF
--- a/src/AssignTransfer/components/OffenderResults.js
+++ b/src/AssignTransfer/components/OffenderResults.js
@@ -23,10 +23,6 @@ class OffenderResults extends Component {
     }
   }
 
-  getOffenderLink (offenderNo) {
-    return `${(process.env.NN_ENDPOINT_URL || 'http://notm-dev.hmpps.dsd.test:3000/')}bookings/${offenderNo}/personal`;
-  }
-
   buildTableForRender (keyworkerOptions, offenderList) {
     if (!offenderList || offenderList.length === 0) {
       return <h1 className="error-message padding-top padding-bottom">No results found</h1>;

--- a/src/AssignTransfer/components/OffenderResults.js
+++ b/src/AssignTransfer/components/OffenderResults.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { properCaseName } from '../../stringUtils';
+import { getOffenderLink } from "../../links";
 //import ReactTooltip from 'react-tooltip';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
@@ -22,6 +23,10 @@ class OffenderResults extends Component {
     }
   }
 
+  getOffenderLink (offenderNo) {
+    return `${(process.env.NN_ENDPOINT_URL || 'http://notm-dev.hmpps.dsd.test:3000/')}bookings/${offenderNo}/personal`;
+  }
+
   buildTableForRender (keyworkerOptions, offenderList) {
     if (!offenderList || offenderList.length === 0) {
       return <h1 className="error-message padding-top padding-bottom">No results found</h1>;
@@ -31,7 +36,7 @@ class OffenderResults extends Component {
         this.props.keyworkerChangeList[index].staffId : '';
       return (<tr key={a.bookingId} className="row-gutters">
         <td className="row-gutters"><a
-          href={a.bookingId}>{properCaseName(a.lastName)}, {properCaseName(a.firstName)}</a></td>
+          href={getOffenderLink(a.offenderNo)}>{properCaseName(a.lastName)}, {properCaseName(a.firstName)}</a></td>
         <td className="row-gutters">{a.offenderNo}</td>
         <td className="row-gutters">{a.assignedLivingUnitDesc}</td>
         <td className="row-gutters">{a.confirmedReleaseDate || "--"}</td>

--- a/src/KeyworkerProfile/components/KeyworkerProfile.js
+++ b/src/KeyworkerProfile/components/KeyworkerProfile.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Link } from "react-router-dom";
 import MessageBar from "../../MessageBar/index";
 import { getStatusStyle, getStatusDescription } from "../keyworkerStatus";
+import { getOffenderLink } from "../../links";
 
 class KeyworkerProfile extends Component {
   getAllocationStyle () {
@@ -29,7 +30,7 @@ class KeyworkerProfile extends Component {
       const formattedName = properCaseName(a.lastName) + ', ' + properCaseName(a.firstName);
       return (
         <tr key={a.bookingId}>
-          <td className="row-gutters"><a href="">{formattedName}</a></td>
+          <td className="row-gutters"><a href={getOffenderLink(a.offenderNo)}>{formattedName}</a></td>
           <td className="row-gutters">{a.offenderNo}</td>
           <td className="row-gutters">{a.internalLocationDesc}</td>
           <td className="row-gutters">{a.confirmedReleaseDate || '--'}</td>

--- a/src/KeyworkerProfile/tests/keyworkerProfileEditConfirm.test.js
+++ b/src/KeyworkerProfile/tests/keyworkerProfileEditConfirm.test.js
@@ -17,14 +17,14 @@ const keyworker = {
 
 describe('Keyworker Profile Edit component', () => {
   it('should render component correctly w with INACTIVE status', async () => {
-    const component = shallow(<KeyworkerProfileEditConfirm keyworker={keyworker} handleSaveChanges={jest.fn()} handleOptionChange={jest.fn()} status="INACTIVE"/>);
+    const component = shallow(<KeyworkerProfileEditConfirm keyworker={keyworker} handleSaveChanges={jest.fn()} handleCancel={jest.fn()} handleOptionChange={jest.fn()} status="INACTIVE"/>);
     expect(component.text()).toContain('This will remove the key worker from the auto-allocation pool and release all of their allocated offenders');
     expect(component.find('input').length).toEqual(0); //no options shown
     expect(component.find('#keyworker-status').hasClass('inactiveStatus')).toBe(true);
   });
 
   it('should render component correctly w with UNAVAILABLE status', async () => {
-    const component = shallow(<KeyworkerProfileEditConfirm keyworker={keyworker} handleSaveChanges={jest.fn()} handleOptionChange={jest.fn()} status="UNAVAILABLE_ANNUAL_LEAVE"/>);
+    const component = shallow(<KeyworkerProfileEditConfirm keyworker={keyworker} handleSaveChanges={jest.fn()} handleCancel={jest.fn()} handleOptionChange={jest.fn()} status="UNAVAILABLE_ANNUAL_LEAVE"/>);
     console.log("debug output " + component.debug());
     expect(component.text()).toContain('Choose an option');
     expect(component.find('input').length).toEqual(3);
@@ -35,7 +35,7 @@ describe('Keyworker Profile Edit component', () => {
   it('should handle save click correctly', async () => {
     let handleSave = jest.fn();
 
-    const component = shallow(<KeyworkerProfileEditConfirm keyworker={keyworker} handleSaveChanges={handleSave} handleOptionChange={jest.fn()} />);
+    const component = shallow(<KeyworkerProfileEditConfirm keyworker={keyworker} handleSaveChanges={handleSave} handleCancel={jest.fn()} handleOptionChange={jest.fn()} />);
 
     component.find('#saveButton').simulate('click');
     expect(handleSave.mock.calls.length).toEqual(1);

--- a/src/ManualAllocation/index.js
+++ b/src/ManualAllocation/index.js
@@ -4,6 +4,7 @@ import ReactTooltip from 'react-tooltip';
 import DateFilter from '../DateFilter/index.js';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
+import { getOffenderLink } from "../links";
 
 class ManualAllocation extends Component {
   buildTableForRender (keyworkerOptions) {
@@ -17,7 +18,7 @@ class ManualAllocation extends Component {
       return (
         <tr key={a.offenderNo} className="row-gutters">
           <td className="row-gutters"><a
-            href={a.offenderNo}>{properCaseName(a.lastName)}, {properCaseName(a.firstName)}</a></td>
+            href={getOffenderLink(a.offenderNo)}>{properCaseName(a.lastName)}, {properCaseName(a.firstName)}</a></td>
           <td className="row-gutters">{a.offenderNo}</td>
           <td className="row-gutters">{a.internalLocationDesc}</td>
           <td className="row-gutters">{a.confirmedReleaseDate || '--'}</td>

--- a/src/Unallocated/__snapshots__/unallocated.test.js.snap
+++ b/src/Unallocated/__snapshots__/unallocated.test.js.snap
@@ -79,7 +79,7 @@ ShallowWrapper {
                                                   className="row-gutters"
                                         >
                                                   <a
-                                                            href={1}
+                                                            href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ124WX/personal"
                                                   >
                                                             Rendell, Steve
                                                   </a>
@@ -110,7 +110,7 @@ ShallowWrapper {
                                                   className="row-gutters"
                                         >
                                                   <a
-                                                            href={2}
+                                                            href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ125WX/personal"
                                                   >
                                                             Rendell2, Steve2
                                                   </a>
@@ -191,7 +191,7 @@ ShallowWrapper {
                                                         className="row-gutters"
                                           >
                                                         <a
-                                                                      href={1}
+                                                                      href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ124WX/personal"
                                                         >
                                                                       Rendell, Steve
                                                         </a>
@@ -222,7 +222,7 @@ ShallowWrapper {
                                                         className="row-gutters"
                                           >
                                                         <a
-                                                                      href={2}
+                                                                      href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ125WX/personal"
                                                         >
                                                                       Rendell2, Steve2
                                                         </a>
@@ -309,7 +309,7 @@ ShallowWrapper {
                                                       className="row-gutters"
                                     >
                                                       <a
-                                                                        href={1}
+                                                                        href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ124WX/personal"
                                                       >
                                                                         Rendell, Steve
                                                       </a>
@@ -340,7 +340,7 @@ ShallowWrapper {
                                                       className="row-gutters"
                                     >
                                                       <a
-                                                                        href={2}
+                                                                        href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ125WX/personal"
                                                       >
                                                                         Rendell2, Steve2
                                                       </a>
@@ -491,7 +491,7 @@ ShallowWrapper {
                                             className="row-gutters"
                       >
                                             <a
-                                                                  href={1}
+                                                                  href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ124WX/personal"
                                             >
                                                                   Rendell, Steve
                                             </a>
@@ -522,7 +522,7 @@ ShallowWrapper {
                                             className="row-gutters"
                       >
                                             <a
-                                                                  href={2}
+                                                                  href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ125WX/personal"
                                             >
                                                                   Rendell2, Steve2
                                             </a>
@@ -562,7 +562,7 @@ ShallowWrapper {
                           className="row-gutters"
 >
                           <a
-                                                    href={1}
+                                                    href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ124WX/personal"
                           >
                                                     Rendell, Steve
                           </a>
@@ -597,7 +597,7 @@ ShallowWrapper {
                         "nodeType": "host",
                         "props": Object {
                           "children": <a
-                            href={1}
+                            href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ124WX/personal"
 >
                             Rendell, Steve
 </a>,
@@ -610,7 +610,7 @@ ShallowWrapper {
                           "nodeType": "host",
                           "props": Object {
                             "children": "Rendell, Steve",
-                            "href": 1,
+                            "href": "http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ124WX/personal",
                           },
                           "ref": null,
                           "rendered": "Rendell, Steve",
@@ -679,7 +679,7 @@ ShallowWrapper {
                           className="row-gutters"
 >
                           <a
-                                                    href={2}
+                                                    href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ125WX/personal"
                           >
                                                     Rendell2, Steve2
                           </a>
@@ -714,7 +714,7 @@ ShallowWrapper {
                         "nodeType": "host",
                         "props": Object {
                           "children": <a
-                            href={2}
+                            href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ125WX/personal"
 >
                             Rendell2, Steve2
 </a>,
@@ -727,7 +727,7 @@ ShallowWrapper {
                           "nodeType": "host",
                           "props": Object {
                             "children": "Rendell2, Steve2",
-                            "href": 2,
+                            "href": "http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ125WX/personal",
                           },
                           "ref": null,
                           "rendered": "Rendell2, Steve2",
@@ -870,7 +870,7 @@ ShallowWrapper {
                                                             className="row-gutters"
                                                 >
                                                             <a
-                                                                        href={1}
+                                                                        href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ124WX/personal"
                                                             >
                                                                         Rendell, Steve
                                                             </a>
@@ -901,7 +901,7 @@ ShallowWrapper {
                                                             className="row-gutters"
                                                 >
                                                             <a
-                                                                        href={2}
+                                                                        href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ125WX/personal"
                                                             >
                                                                         Rendell2, Steve2
                                                             </a>
@@ -982,7 +982,7 @@ ShallowWrapper {
                                                                 className="row-gutters"
                                                 >
                                                                 <a
-                                                                                href={1}
+                                                                                href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ124WX/personal"
                                                                 >
                                                                                 Rendell, Steve
                                                                 </a>
@@ -1013,7 +1013,7 @@ ShallowWrapper {
                                                                 className="row-gutters"
                                                 >
                                                                 <a
-                                                                                href={2}
+                                                                                href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ125WX/personal"
                                                                 >
                                                                                 Rendell2, Steve2
                                                                 </a>
@@ -1100,7 +1100,7 @@ ShallowWrapper {
                                                             className="row-gutters"
                                         >
                                                             <a
-                                                                                href={1}
+                                                                                href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ124WX/personal"
                                                             >
                                                                                 Rendell, Steve
                                                             </a>
@@ -1131,7 +1131,7 @@ ShallowWrapper {
                                                             className="row-gutters"
                                         >
                                                             <a
-                                                                                href={2}
+                                                                                href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ125WX/personal"
                                                             >
                                                                                 Rendell2, Steve2
                                                             </a>
@@ -1282,7 +1282,7 @@ ShallowWrapper {
                                                 className="row-gutters"
                         >
                                                 <a
-                                                                        href={1}
+                                                                        href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ124WX/personal"
                                                 >
                                                                         Rendell, Steve
                                                 </a>
@@ -1313,7 +1313,7 @@ ShallowWrapper {
                                                 className="row-gutters"
                         >
                                                 <a
-                                                                        href={2}
+                                                                        href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ125WX/personal"
                                                 >
                                                                         Rendell2, Steve2
                                                 </a>
@@ -1353,7 +1353,7 @@ ShallowWrapper {
                             className="row-gutters"
 >
                             <a
-                                                        href={1}
+                                                        href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ124WX/personal"
                             >
                                                         Rendell, Steve
                             </a>
@@ -1388,7 +1388,7 @@ ShallowWrapper {
                           "nodeType": "host",
                           "props": Object {
                             "children": <a
-                              href={1}
+                              href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ124WX/personal"
 >
                               Rendell, Steve
 </a>,
@@ -1401,7 +1401,7 @@ ShallowWrapper {
                             "nodeType": "host",
                             "props": Object {
                               "children": "Rendell, Steve",
-                              "href": 1,
+                              "href": "http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ124WX/personal",
                             },
                             "ref": null,
                             "rendered": "Rendell, Steve",
@@ -1470,7 +1470,7 @@ ShallowWrapper {
                             className="row-gutters"
 >
                             <a
-                                                        href={2}
+                                                        href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ125WX/personal"
                             >
                                                         Rendell2, Steve2
                             </a>
@@ -1505,7 +1505,7 @@ ShallowWrapper {
                           "nodeType": "host",
                           "props": Object {
                             "children": <a
-                              href={2}
+                              href="http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ125WX/personal"
 >
                               Rendell2, Steve2
 </a>,
@@ -1518,7 +1518,7 @@ ShallowWrapper {
                             "nodeType": "host",
                             "props": Object {
                               "children": "Rendell2, Steve2",
-                              "href": 2,
+                              "href": "http://notm-dev.hmpps.dsd.test:3000/offenders/ZZ125WX/personal",
                             },
                             "ref": null,
                             "rendered": "Rendell2, Steve2",

--- a/src/Unallocated/index.js
+++ b/src/Unallocated/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { properCaseName } from "../stringUtils";
 import PropTypes from 'prop-types';
+import { getOffenderLink } from "../links";
 
 class Unallocated extends Component {
   render () {
@@ -8,7 +9,7 @@ class Unallocated extends Component {
       const formattedName = properCaseName(a.lastName) + ', ' + properCaseName(a.firstName);
       return (
         <tr key={a.bookingId}>
-          <td className="row-gutters"><a href={a.bookingId}>{formattedName}</a></td>
+          <td className="row-gutters"><a href={getOffenderLink(a.offenderNo)}>{formattedName}</a></td>
           <td className="row-gutters">{a.offenderNo}</td>
           <td className="row-gutters">{a.assignedLivingUnitDesc}</td>
           <td className="row-gutters">{a.confirmedReleaseDate || '--'}</td>

--- a/src/links.js
+++ b/src/links.js
@@ -1,0 +1,9 @@
+const getOffenderLink = (offenderNo) => {
+  return `${(process.env.NN_ENDPOINT_URL || 'http://notm-dev.hmpps.dsd.test:3000/')}offenders/${offenderNo}/personal`;
+};
+
+const links = {
+  getOffenderLink
+};
+
+module.exports = links;


### PR DESCRIPTION
env variable for new nomis is - NN_ENDPOINT_URL
Agreed with Steven Babaga that the offender path on new nomis will change to 
/offenders/{offenderId}/personal