### PR TITLE
NN-643 OMIC add links to view offender details: configure host

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -1,6 +1,7 @@
 module.exports = {
   app: {
-    production: process.env.NODE_ENV === 'production'
+    production: process.env.NODE_ENV === 'production',
+    notmEndpointUrl: process.env.NN_ENDPOINT_URL || 'localhost:3000'
   },
   hmppsCookie: {
     name: process.env.HMPPS_COOKIE_NAME || 'hmpps-session-dev',

--- a/backend/controllers/userMe.js
+++ b/backend/controllers/userMe.js
@@ -2,9 +2,11 @@ const express = require('express');
 const router = express.Router();
 const elite2Api = require('../elite2Api');
 const asyncMiddleware = require('../middleware/asyncHandler');
+const config = require('../config');
 
 router.get('/', asyncMiddleware(async (req, res) => {
   const response = await elite2Api.currentUser(req, res);
+  response.data.notmEndpointUrl = config.app.notmEndpointUrl;
   res.json(response.data);
 }));
 

--- a/src/AssignTransfer/components/OffenderResults.js
+++ b/src/AssignTransfer/components/OffenderResults.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { properCaseName } from '../../stringUtils';
 import { getOffenderLink } from "../../links";
-//import ReactTooltip from 'react-tooltip';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import OffenderSearchContainer from "../containers/OffenderSearchContainer";

--- a/src/AutoAllocation/tests/__snapshots__/unallocated.test.js.snap
+++ b/src/AutoAllocation/tests/__snapshots__/unallocated.test.js.snap
@@ -80,7 +80,7 @@ ShallowWrapper {
                                                   className="row-gutters"
                                         >
                                                   <a
-                                                            href="https://notm-dev.hmpps.dsd.io/offenders/ZZ124WX/personal"
+                                                            href="http://my.testUrl/offenders/ZZ124WX/personal"
                                                   >
                                                             Rendell, Steve
                                                   </a>
@@ -111,7 +111,7 @@ ShallowWrapper {
                                                   className="row-gutters"
                                         >
                                                   <a
-                                                            href="https://notm-dev.hmpps.dsd.io/offenders/ZZ125WX/personal"
+                                                            href="http://my.testUrl/offenders/ZZ125WX/personal"
                                                   >
                                                             Rendell2, Steve2
                                                   </a>
@@ -192,7 +192,7 @@ ShallowWrapper {
                                                         className="row-gutters"
                                           >
                                                         <a
-                                                                      href="https://notm-dev.hmpps.dsd.io/offenders/ZZ124WX/personal"
+                                                                      href="http://my.testUrl/offenders/ZZ124WX/personal"
                                                         >
                                                                       Rendell, Steve
                                                         </a>
@@ -223,7 +223,7 @@ ShallowWrapper {
                                                         className="row-gutters"
                                           >
                                                         <a
-                                                                      href="https://notm-dev.hmpps.dsd.io/offenders/ZZ125WX/personal"
+                                                                      href="http://my.testUrl/offenders/ZZ125WX/personal"
                                                         >
                                                                       Rendell2, Steve2
                                                         </a>
@@ -311,7 +311,7 @@ ShallowWrapper {
                                                       className="row-gutters"
                                     >
                                                       <a
-                                                                        href="https://notm-dev.hmpps.dsd.io/offenders/ZZ124WX/personal"
+                                                                        href="http://my.testUrl/offenders/ZZ124WX/personal"
                                                       >
                                                                         Rendell, Steve
                                                       </a>
@@ -342,7 +342,7 @@ ShallowWrapper {
                                                       className="row-gutters"
                                     >
                                                       <a
-                                                                        href="https://notm-dev.hmpps.dsd.io/offenders/ZZ125WX/personal"
+                                                                        href="http://my.testUrl/offenders/ZZ125WX/personal"
                                                       >
                                                                         Rendell2, Steve2
                                                       </a>
@@ -493,7 +493,7 @@ ShallowWrapper {
                                             className="row-gutters"
                       >
                                             <a
-                                                                  href="https://notm-dev.hmpps.dsd.io/offenders/ZZ124WX/personal"
+                                                                  href="http://my.testUrl/offenders/ZZ124WX/personal"
                                             >
                                                                   Rendell, Steve
                                             </a>
@@ -524,7 +524,7 @@ ShallowWrapper {
                                             className="row-gutters"
                       >
                                             <a
-                                                                  href="https://notm-dev.hmpps.dsd.io/offenders/ZZ125WX/personal"
+                                                                  href="http://my.testUrl/offenders/ZZ125WX/personal"
                                             >
                                                                   Rendell2, Steve2
                                             </a>
@@ -564,7 +564,7 @@ ShallowWrapper {
                           className="row-gutters"
 >
                           <a
-                                                    href="https://notm-dev.hmpps.dsd.io/offenders/ZZ124WX/personal"
+                                                    href="http://my.testUrl/offenders/ZZ124WX/personal"
                           >
                                                     Rendell, Steve
                           </a>
@@ -599,7 +599,7 @@ ShallowWrapper {
                         "nodeType": "host",
                         "props": Object {
                           "children": <a
-                            href="https://notm-dev.hmpps.dsd.io/offenders/ZZ124WX/personal"
+                            href="http://my.testUrl/offenders/ZZ124WX/personal"
 >
                             Rendell, Steve
 </a>,
@@ -612,7 +612,7 @@ ShallowWrapper {
                           "nodeType": "host",
                           "props": Object {
                             "children": "Rendell, Steve",
-                            "href": "https://notm-dev.hmpps.dsd.io/offenders/ZZ124WX/personal",
+                            "href": "http://my.testUrl/offenders/ZZ124WX/personal",
                           },
                           "ref": null,
                           "rendered": "Rendell, Steve",
@@ -681,7 +681,7 @@ ShallowWrapper {
                           className="row-gutters"
 >
                           <a
-                                                    href="https://notm-dev.hmpps.dsd.io/offenders/ZZ125WX/personal"
+                                                    href="http://my.testUrl/offenders/ZZ125WX/personal"
                           >
                                                     Rendell2, Steve2
                           </a>
@@ -716,7 +716,7 @@ ShallowWrapper {
                         "nodeType": "host",
                         "props": Object {
                           "children": <a
-                            href="https://notm-dev.hmpps.dsd.io/offenders/ZZ125WX/personal"
+                            href="http://my.testUrl/offenders/ZZ125WX/personal"
 >
                             Rendell2, Steve2
 </a>,
@@ -729,7 +729,7 @@ ShallowWrapper {
                           "nodeType": "host",
                           "props": Object {
                             "children": "Rendell2, Steve2",
-                            "href": "https://notm-dev.hmpps.dsd.io/offenders/ZZ125WX/personal",
+                            "href": "http://my.testUrl/offenders/ZZ125WX/personal",
                           },
                           "ref": null,
                           "rendered": "Rendell2, Steve2",
@@ -873,7 +873,7 @@ ShallowWrapper {
                                                             className="row-gutters"
                                                 >
                                                             <a
-                                                                        href="https://notm-dev.hmpps.dsd.io/offenders/ZZ124WX/personal"
+                                                                        href="http://my.testUrl/offenders/ZZ124WX/personal"
                                                             >
                                                                         Rendell, Steve
                                                             </a>
@@ -904,7 +904,7 @@ ShallowWrapper {
                                                             className="row-gutters"
                                                 >
                                                             <a
-                                                                        href="https://notm-dev.hmpps.dsd.io/offenders/ZZ125WX/personal"
+                                                                        href="http://my.testUrl/offenders/ZZ125WX/personal"
                                                             >
                                                                         Rendell2, Steve2
                                                             </a>
@@ -985,7 +985,7 @@ ShallowWrapper {
                                                                 className="row-gutters"
                                                 >
                                                                 <a
-                                                                                href="https://notm-dev.hmpps.dsd.io/offenders/ZZ124WX/personal"
+                                                                                href="http://my.testUrl/offenders/ZZ124WX/personal"
                                                                 >
                                                                                 Rendell, Steve
                                                                 </a>
@@ -1016,7 +1016,7 @@ ShallowWrapper {
                                                                 className="row-gutters"
                                                 >
                                                                 <a
-                                                                                href="https://notm-dev.hmpps.dsd.io/offenders/ZZ125WX/personal"
+                                                                                href="http://my.testUrl/offenders/ZZ125WX/personal"
                                                                 >
                                                                                 Rendell2, Steve2
                                                                 </a>
@@ -1104,7 +1104,7 @@ ShallowWrapper {
                                                             className="row-gutters"
                                         >
                                                             <a
-                                                                                href="https://notm-dev.hmpps.dsd.io/offenders/ZZ124WX/personal"
+                                                                                href="http://my.testUrl/offenders/ZZ124WX/personal"
                                                             >
                                                                                 Rendell, Steve
                                                             </a>
@@ -1135,7 +1135,7 @@ ShallowWrapper {
                                                             className="row-gutters"
                                         >
                                                             <a
-                                                                                href="https://notm-dev.hmpps.dsd.io/offenders/ZZ125WX/personal"
+                                                                                href="http://my.testUrl/offenders/ZZ125WX/personal"
                                                             >
                                                                                 Rendell2, Steve2
                                                             </a>
@@ -1286,7 +1286,7 @@ ShallowWrapper {
                                                 className="row-gutters"
                         >
                                                 <a
-                                                                        href="https://notm-dev.hmpps.dsd.io/offenders/ZZ124WX/personal"
+                                                                        href="http://my.testUrl/offenders/ZZ124WX/personal"
                                                 >
                                                                         Rendell, Steve
                                                 </a>
@@ -1317,7 +1317,7 @@ ShallowWrapper {
                                                 className="row-gutters"
                         >
                                                 <a
-                                                                        href="https://notm-dev.hmpps.dsd.io/offenders/ZZ125WX/personal"
+                                                                        href="http://my.testUrl/offenders/ZZ125WX/personal"
                                                 >
                                                                         Rendell2, Steve2
                                                 </a>
@@ -1357,7 +1357,7 @@ ShallowWrapper {
                             className="row-gutters"
 >
                             <a
-                                                        href="https://notm-dev.hmpps.dsd.io/offenders/ZZ124WX/personal"
+                                                        href="http://my.testUrl/offenders/ZZ124WX/personal"
                             >
                                                         Rendell, Steve
                             </a>
@@ -1392,7 +1392,7 @@ ShallowWrapper {
                           "nodeType": "host",
                           "props": Object {
                             "children": <a
-                              href="https://notm-dev.hmpps.dsd.io/offenders/ZZ124WX/personal"
+                              href="http://my.testUrl/offenders/ZZ124WX/personal"
 >
                               Rendell, Steve
 </a>,
@@ -1405,7 +1405,7 @@ ShallowWrapper {
                             "nodeType": "host",
                             "props": Object {
                               "children": "Rendell, Steve",
-                              "href": "https://notm-dev.hmpps.dsd.io/offenders/ZZ124WX/personal",
+                              "href": "http://my.testUrl/offenders/ZZ124WX/personal",
                             },
                             "ref": null,
                             "rendered": "Rendell, Steve",
@@ -1474,7 +1474,7 @@ ShallowWrapper {
                             className="row-gutters"
 >
                             <a
-                                                        href="https://notm-dev.hmpps.dsd.io/offenders/ZZ125WX/personal"
+                                                        href="http://my.testUrl/offenders/ZZ125WX/personal"
                             >
                                                         Rendell2, Steve2
                             </a>
@@ -1509,7 +1509,7 @@ ShallowWrapper {
                           "nodeType": "host",
                           "props": Object {
                             "children": <a
-                              href="https://notm-dev.hmpps.dsd.io/offenders/ZZ125WX/personal"
+                              href="http://my.testUrl/offenders/ZZ125WX/personal"
 >
                               Rendell2, Steve2
 </a>,
@@ -1522,7 +1522,7 @@ ShallowWrapper {
                             "nodeType": "host",
                             "props": Object {
                               "children": "Rendell2, Steve2",
-                              "href": "https://notm-dev.hmpps.dsd.io/offenders/ZZ125WX/personal",
+                              "href": "http://my.testUrl/offenders/ZZ125WX/personal",
                             },
                             "ref": null,
                             "rendered": "Rendell2, Steve2",

--- a/src/AutoAllocation/tests/unallocated.test.js
+++ b/src/AutoAllocation/tests/unallocated.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Enzyme, { shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import Unallocated from '../components/Unallocated';
+import links from "../../links";
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -26,6 +27,7 @@ const list = [{
 
 describe('Unallocated component', () => {
   it('should render list correctly', () => {
+    links.notmEndpointUrl = "http://my.testUrl";
     const component = shallow(<Unallocated loaded unallocatedList={list} gotoNext={() => {}} />);
 
     expect(component).toMatchSnapshot();

--- a/src/KeyworkerManagement/App.js
+++ b/src/KeyworkerManagement/App.js
@@ -21,6 +21,7 @@ import axiosWrapper from "../backendWrapper";
 import PropTypes from 'prop-types';
 import { switchAgency, setTermsVisibility, setError, resetError, setUserDetails, setMessage } from '../redux/actions/index';
 import { connect } from 'react-redux';
+import links from "../links";
 
 const axios = require('axios');
 
@@ -42,6 +43,8 @@ class App extends React.Component {
 
     try {
       const user = await axiosWrapper.get('/api/me');
+      links.notmEndpointUrl = user.data.notmEndpointUrl;
+
       const caseloads = await axiosWrapper.get('/api/usercaseloads');
       this.props.userDetailsDispatch({ ...user.data, caseLoadOptions: caseloads.data });
     } catch (error) {

--- a/src/links.js
+++ b/src/links.js
@@ -1,8 +1,9 @@
 const getOffenderLink = (offenderNo) => {
-  return `https://notm-dev.hmpps.dsd.io/offenders/${offenderNo}/personal`;
+  return `${links.notmEndpointUrl}/offenders/${offenderNo}/personal`;
 };
 
 const links = {
+  notmEndpointUrl: '', // set from env by /user/me call
   getOffenderLink
 };
 


### PR DESCRIPTION
Not sure about this one, maybe better to pull hostname directly from state? Or use dedicated api call?