### PR TITLE
Add hyperlink for staff to their profile.

### DIFF
--- a/src/AssignTransfer/components/OffenderResults.js
+++ b/src/AssignTransfer/components/OffenderResults.js
@@ -1,23 +1,28 @@
 import React, { Component } from 'react';
 import { properCaseName } from '../../stringUtils';
 import { getOffenderLink } from "../../links";
+import { getStaffLink } from "../../links";
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import OffenderSearchContainer from "../containers/OffenderSearchContainer";
 import { Link } from "react-router-dom";
 
 class OffenderResults extends Component {
+  buildKeyworkerDisplay (staffId, keyworkerDisplay, numberAllocated) {
+    if (keyworkerDisplay) {
+      if (numberAllocated || numberAllocated === 0) {
+        return keyworkerDisplay + ' (' + numberAllocated + ')';
+      } else {
+        return keyworkerDisplay;
+      }
+    } else {
+      return staffId + ' (no details available)';
+    }
+  }
+
   getKeyworkerDisplay (staffId, keyworkerDisplay, numberAllocated) {
     if (staffId) {
-      if (keyworkerDisplay) {
-        if (numberAllocated || numberAllocated === 0) {
-          return keyworkerDisplay + ' (' + numberAllocated + ')';
-        } else {
-          return keyworkerDisplay;
-        }
-      } else {
-        return staffId + ' (no details available)';
-      }
+      return <a className="link" href={getStaffLink(staffId)}>{this.buildKeyworkerDisplay(staffId, keyworkerDisplay, numberAllocated)}</a>;
     } else {
       return <strong className="bold-xsmall">Not allocated</strong>;
     }

--- a/src/AutoAllocation/components/Provisional.js
+++ b/src/AutoAllocation/components/Provisional.js
@@ -3,20 +3,24 @@ import { properCaseName } from '../../stringUtils';
 import DateFilter from '../../DateFilter/index.js';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
-import { getOffenderLink } from "../../links";
+import { getOffenderLink, getStaffLink } from "../../links";
 
 class Provisional extends Component {
+  buildKeyworkerDisplay (staffId, keyworkerDisplay, numberAllocated) {
+    if (keyworkerDisplay !== '--') {
+      if (numberAllocated || numberAllocated === 0) {
+        return keyworkerDisplay + ' (' + numberAllocated + ')';
+      } else {
+        return keyworkerDisplay;
+      }
+    } else {
+      return staffId + ' (no details available)';
+    }
+  }
+
   getKeyworkerDisplay (staffId, keyworkerDisplay, numberAllocated) {
     if (staffId) {
-      if (keyworkerDisplay !== '--') {
-        if (numberAllocated || numberAllocated === 0) {
-          return keyworkerDisplay + ' (' + numberAllocated + ')';
-        } else {
-          return keyworkerDisplay;
-        }
-      } else {
-        return staffId + ' (no details available)';
-      }
+      return <a className="link" target="_blank" href={getStaffLink(staffId)}>{this.buildKeyworkerDisplay(staffId, keyworkerDisplay, numberAllocated)}</a>;
     } else {
       return <strong className="bold-xsmall">Not allocated</strong>;
     }

--- a/src/links.js
+++ b/src/links.js
@@ -2,9 +2,15 @@ const getOffenderLink = (offenderNo) => {
   return `${links.notmEndpointUrl}offenders/${offenderNo}/personal`;
 };
 
+const getStaffLink = (staffId) => {
+  return `/keyworker/${staffId}/profile`;
+};
+
+
 const links = {
   notmEndpointUrl: '', // set from env by /api/config call
-  getOffenderLink
+  getOffenderLink,
+  getStaffLink
 };
 
 module.exports = links;


### PR DESCRIPTION
This will allow you to look up the staff profile in more detail from the offender results page.  In allocation mode it opens a new tab to prevent navigation away.  Obs, need a better nav strategy going forward, but will suffice for now.